### PR TITLE
Add stdout output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "prtsc-wayland"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prtsc-wayland"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
  Usage: prtsc-wayland [OPTIONS]
 
 Options:
-  -o, --output <OUTPUT>  File to save screenshot [default: image.png]
+  -o, --output <OUTPUT>  File to save screenshot (use '-' to output to stdout) [default: image.png]
   -f, --fullscreen       Do not use region selector
   -h, --help             Print help
 ```


### PR DESCRIPTION
This simple PR adds ability to output screenshot png image to stdout, by specifying `-o -` instead of the file name `-o example.png`

It is similar to `grim` where you can specify `-` instead of the file name

Usage example:

```bash
# Now we can immediately copy screenshot to clipboard!
prtsc-wayland -o - | wl-copy
```

EDIT: add more info