### PR TITLE
Added flakes for nixos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # 'Build for NixOS'
- `git clone https://github.com/VOXEL0798/prtsc-wayland.git`
- `nix build`
+ `git clone https://github.com/VOXEL0798/prtsc-wayland.git` + `nix build`
 
 # `prtsc-wayland`
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# 'Build for NixOS'
+ `git clone https://github.com/VOXEL0798/prtsc-wayland.git`
+ `nix build`
+
 # `prtsc-wayland`
 
 > 📸 Screenshot utility for wayland

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Build for NixOS
- `git clone https://github.com/VOXEL0798/prtsc-wayland.git` + `nix develop` + `cargo build --release`
-
 # `prtsc-wayland`
 
 > 📸 Screenshot utility for wayland

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 'Build for NixOS'
+# Build for NixOS
  `git clone https://github.com/VOXEL0798/prtsc-wayland.git` + `nix build`
 
 # `prtsc-wayland`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Build for NixOS
- `git clone https://github.com/VOXEL0798/prtsc-wayland.git` + `nix build`
+ `git clone https://github.com/VOXEL0798/prtsc-wayland.git` + `nix develop` + `cargo build --release`
 
 # `prtsc-wayland`
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745930157,
+        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,9 +32,10 @@
       };
     in
     {
-      packages.${system}.default = prtsc-wayland;
-
-      defaultPackage.${system} = prtsc-wayland;
+      packages = {
+        prtsc-wayland = prtsc-wayland;
+        default = prtsc-wayland;
+      };
 
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  description = "Screenshot utility for Wayland";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      rustPlatform = pkgs.makeRustPlatform {
+        cargo = pkgs.cargo;
+        rustc = pkgs.rustc;
+      };
+    in
+    {
+      packages.${system}.default = rustPlatform.buildRustPackage {
+        pname = "prtsc-wayland";
+        version = "0.3.0";
+        src = ./.;
+
+        cargoLock = {
+          lockFile = ./Cargo.lock;
+        };
+
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+        ];
+
+        buildInputs = with pkgs; [
+          wayland
+          libxkbcommon
+        ];
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          rustc
+          cargo
+          pkg-config
+          wayland
+          libxkbcommon
+        ];
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "Screenshot utility for Wayland";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -10,9 +11,8 @@
         cargo = pkgs.cargo;
         rustc = pkgs.rustc;
       };
-    in
-    {
-      packages.${system}.default = rustPlatform.buildRustPackage {
+
+      prtsc-wayland = rustPlatform.buildRustPackage {
         pname = "prtsc-wayland";
         version = "0.3.0";
         src = ./.;
@@ -30,6 +30,11 @@
           libxkbcommon
         ];
       };
+    in
+    {
+      packages.${system}.default = prtsc-wayland;
+
+      defaultPackage.${system} = prtsc-wayland;
 
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = with pkgs; [
@@ -42,3 +47,4 @@
       };
     };
 }
+

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
       };
     in
     {
-      packages = {
+      packages.${system} = {
         prtsc-wayland = prtsc-wayland;
         default = prtsc-wayland;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
       prtsc-wayland = rustPlatform.buildRustPackage {
         pname = "prtsc-wayland";
-        version = "0.3.0";
+        version = "0.3.1";
         src = ./.;
 
         cargoLock = {


### PR DESCRIPTION
I added flakes to enable building the project on NixOS using `nix develop`.

Usage example:
```
nix develop
cargo build --release
```

EDIT:
The flake.nix file simplifies dependency management and ensures reproducible builds in Nix projects by declaratively defining dependencies and configurations.